### PR TITLE
added storage into the submit event

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -119,22 +119,29 @@ let scores = [];
 let getScores = JSON.parse(localStorage.getItem('scores'))
 // let scoresArray = JSON.parse(getScores);
 
-submitBtn.addEventListener ('click', function(){
+submitBtn.addEventListener ('click', function(e){
     let scoreInput = document.getElementById('initials-score').value
     scores.push(scoreInput);
+    let newScoreArray = scores.concat(getScores);
+    e.preventDefault();
+    console.log(e);
+    let scoreString = JSON.stringify(newScoreArray);
+    localStorage.setItem('scores', scoreString);
+    input = " "
+
     // let scoreString = JSON.stringify(scores);
     // // let savedScores = 
     // localStorage.setItem('scores', scoreString);
     // getNewScores();
-    storeScores();
+    // storeScores();
     console.log(`Thanks for submitting your scores! Your score will be logged as ${scoreInput}`);
     
 })
 
-storeScores = () => {
-    let scoreString = JSON.stringify(scores);
-    localStorage.setItem('scores', scoreString);
-}
+// storeScores = () => {
+//     let scoreString = JSON.stringify(newScoreArray);
+//     localStorage.setItem('scores', scoreString);
+// }
 
 // This function will retrieve the scores from local storage.
 highScores.addEventListener ('click', function () {
@@ -142,15 +149,16 @@ highScores.addEventListener ('click', function () {
 })
 
 getNewScores = () => {
-    let getScores = localStorage.getItem('scores')
-    let scoresArray = JSON.parse(getScores);
+    // let getScores = localStorage.getItem('scores')
+    let getScores = JSON.parse(localStorage.getItem('scores'))
+    // let scoresArray = JSON.parse(getScores);
     console.log(getScores);
+}
 
-    for (let i = 0; i < scoresArray.length; i++) {
+    for (let i = 0; i < getScores.length; i++) {
         let scoresLI = document.createElement('li');
         scoreOL.appendChild(scoresLI);
-        scoresLI.innerText = scoresArray[i];
+        scoresLI.innerText = getScores[i];
     }
-    
-}
+
 


### PR DESCRIPTION
This PR reincorporates the local storage statements back into the submit event listener in order to access the new array created and concatenate it with the scores already in storage.  This allows the new scores submitted to be combined with existing scores in storage to persist across sessions and page refreshes.   The prevent default behavior of the submit event was also added to stop the page from automatically refreshing after a user submits their score.