### PR TITLE
added statement to hide scores

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -271,6 +271,7 @@ let getNewScores = () => {
 // The following code allows users to restart the quiz by refreshing the page if they would like to do so.
 restartQuiz.addEventListener('click', function(e) {
     reloadQuiz();
+    scoreOL.hidden = true;
 })
 
 reloadQuiz = () => {


### PR DESCRIPTION
This PR updates the restart quiz button to hide the high scores on restart.  The quiz scores would display throughout the quiz after being accessed using the high scores link.  This PR addresses that issue.